### PR TITLE
Add drawing storage using managed identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ IaC and Function code
 
 ## Deploy to Azure
 
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https://github.com/krhatland/cloudnet-draw-full-selfhost/blob/main/infra/main.bicep)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fkrhatland%2Fcloudnet-draw-full-selfhost%2Fmain%2Finfra%2Fmain.bicep)
 
 ### Parameters
 
@@ -11,6 +11,7 @@ IaC and Function code
 |-----------------------|----------------------------------------------|
 | `functionAppName`    | Name of the Function App                     |
 | `storageAccountName` | Name of the Storage Account                  |
+| `drawingStorageAccountName` | Name of the Storage Account for diagrams |
 | `appServicePlanName` | Name of the App Service Plan (Consumption)   |
 | `uamiName`           | User Assigned Managed Identity (Optional)    |
 

--- a/function/__init__.py
+++ b/function/__init__.py
@@ -49,8 +49,8 @@ def main(mytimer: func.TimerRequest) -> None:
 
     # Step 4: Upload files to Blob Storage
     credential = DefaultAzureCredential()
-    account_url = "https://cndselfhostrgab91.blob.core.windows.net"
-    container_name = "drawfunc"
+    account_url = os.environ.get("DRAWING_STORAGE_URL")
+    container_name = os.environ.get("DRAWING_CONTAINER_NAME", "drawfunc")
     blob_service_client = BlobServiceClient(account_url=account_url, credential=credential)
 
     # Upload JSON

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -7,6 +7,9 @@ param functionAppName string
 @description('Name for the Storage Account')
 param storageAccountName string
 
+@description('Name for the Storage Account used to store drawings')
+param drawingStorageAccountName string
+
 @description('Name for the App Service Plan')
 param appServicePlanName string
 
@@ -38,6 +41,38 @@ resource storage 'Microsoft.Storage/storageAccounts@2022-09-01' = {
   }
 }
 
+resource drawingStorage 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+  name: drawingStorageAccountName
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    minimumTlsVersion: 'TLS1_2'
+    allowBlobPublicAccess: false
+    networkAcls: {
+      bypass: 'AzureServices'
+      defaultAction: 'Deny'
+    }
+    encryption: {
+      keySource: 'Microsoft.Storage'
+      services: {
+        blob: { enabled: true }
+        file: { enabled: true }
+      }
+    }
+    accessTier: 'Hot'
+  }
+}
+
+resource drawingContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2022-09-01' = {
+  name: '${drawingStorage.name}/default/drawfunc'
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
 resource appServicePlan 'Microsoft.Web/serverfarms@2022-03-01' = {
   name: appServicePlanName
   location: location
@@ -60,9 +95,20 @@ resource functionApp 'Microsoft.Web/sites@2022-03-01' = {
       linuxFxVersion: 'PYTHON|3.10'
       appSettings: [
         { name: 'AzureWebJobsStorage'; value: storage.properties.primaryEndpoints.blob }
+        { name: 'DRAWING_STORAGE_URL'; value: drawingStorage.properties.primaryEndpoints.blob }
+        { name: 'DRAWING_CONTAINER_NAME'; value: 'drawfunc' }
       ]
     }
     httpsOnly: true
+  }
+}
+
+resource drawingStorageRoleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
+  name: guid(functionApp.identity.principalId, drawingStorage.id, 'blobcontrib')
+  scope: drawingStorage
+  properties: {
+    principalId: functionApp.identity.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
   }
 }
 


### PR DESCRIPTION
## Summary
- update README instructions and parameters
- parameterize drawing storage account and container
- add new storage account, container, role assignment in Bicep
- use env vars for drawing storage in the timer function

## Testing
- `python3 -m py_compile function/*.py`
- `flake8 function || true`


------
https://chatgpt.com/codex/tasks/task_b_684735af3c2c8329a1b02fededa97622